### PR TITLE
feat: add workflow keepalive for scheduled jobs

### DIFF
--- a/.github/workflows/ferry_db_snapshot.yml
+++ b/.github/workflows/ferry_db_snapshot.yml
@@ -34,3 +34,11 @@ jobs:
       - name: Delete Old Snapshots
         run: |
           find /home/app/ferry_snapshots -type f -mtime +30 -delete
+
+  workflow-keepalive:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - uses: liskin/gh-workflow-keepalive@v1

--- a/.github/workflows/user_db_backup.yml
+++ b/.github/workflows/user_db_backup.yml
@@ -19,3 +19,11 @@ jobs:
           cd /home/app/infra/db
           git pull
           bash cron_script.sh
+
+  workflow-keepalive:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - uses: liskin/gh-workflow-keepalive@v1


### PR DESCRIPTION
use `liskin/gh-workflow-keepalive@v1` to prevent scheduled actions from getting cancelled due to repository inactivity