### PR TITLE
chore: manage cloudflare transform rules with terraform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,9 @@
 db/db_dumps/*
 node_modules
+
+# Terraform working data and local state. Provider lock files are committed.
+cloudflare/.terraform/
+cloudflare/*.tfstate
+cloudflare/*.tfstate.*
+cloudflare/*.tfvars
+!cloudflare/*.tfvars.example

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 db/db_dumps/*
 node_modules
 
+# Local Cloudflare CLI data.
+.wrangler/
+
 # Terraform working data and local state. Provider lock files are committed.
 cloudflare/.terraform/
 cloudflare/*.tfstate

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ The infrastructure is currently designed to provision on a monolithic VM. Howeve
 
 Each directory denotes a separate Docker Compose configuration, each with its own network.
 
+Cloudflare zone configuration is managed separately under [`cloudflare/`](cloudflare/). See its README before planning or applying changes; the existing production ruleset must be imported before Terraform can manage it safely.
+
 Below is the list of every network and its attached services (including those defined in [coursetable](https://github.com/coursetable/coursetable/)):
 
 - **[`traefik`](traefik/)**

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The infrastructure is currently designed to provision on a monolithic VM. Howeve
 
 Each directory denotes a separate Docker Compose configuration, each with its own network.
 
-Cloudflare zone configuration is managed separately under [`cloudflare/`](cloudflare/). See its README before planning or applying changes; the existing production ruleset must be imported before Terraform can manage it safely.
+Cloudflare zone configuration is managed separately under [`cloudflare/`](cloudflare/) with shared state in R2. See its README before planning or applying changes.
 
 Below is the list of every network and its attached services (including those defined in [coursetable](https://github.com/coursetable/coursetable/)):
 

--- a/cloudflare/.terraform.lock.hcl
+++ b/cloudflare/.terraform.lock.hcl
@@ -1,0 +1,19 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/cloudflare/cloudflare" {
+  version     = "5.23.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Sixlatj4vbZGhJ9r7I5c0l4gWp5Bej0aNR3akDt7wig=",
+    "zh:3492a18e8753c2734bb253b70b46c8ec66151198b5221dc7772dab76778a2c06",
+    "zh:698ca2b12417c7477744e5410796f4fa0311f7882e1a6c790581795182b3905c",
+    "zh:b21e7da03e7529469f042eb5b11d08b084d255ab794bfeec80f6d8a9e8a91df6",
+    "zh:bbd837ccb1e08335aa7473e6c806da4c2ff04c93bfb63f6606bd09efceb82cff",
+    "zh:bdcaa21fe92031f5f043a6774821247a26047db92e5a2abfc4bfbd9262358e0c",
+    "zh:cb2c86565c94822733760015f892c71d3ed886d7db4549c561d62ec7bc20a175",
+    "zh:ccc101c27eec4ffdcbf43eaedc85a5ba5850c29d38dca7b1d7e20d668edb7a96",
+    "zh:e029d245d2470b350e12b4747a9a6c6d637010628bfe4f46644ff79f676f56e5",
+    "zh:f809ab383cca0a5f83072981c64208cbd7fa67e986a86ee02dd2c82333221e32",
+  ]
+}

--- a/cloudflare/README.md
+++ b/cloudflare/README.md
@@ -1,0 +1,66 @@
+# Cloudflare infrastructure
+
+This directory manages CourseTable's zone-level Cloudflare configuration. The first managed resource is the URL Transform Rules ruleset that serves link-preview metadata to social crawlers.
+
+## Safety
+
+`cloudflare_ruleset.link_preview` owns the complete `http_request_transform` phase for `coursetable.com`. Cloudflare and Terraform both require all URL Transform Rules in that phase to live in a single ruleset. **Import the existing production ruleset before running `terraform apply`.** Creating a second unmanaged resource or applying before import can conflict with the live rules.
+
+Terraform state and credentials must not be committed. Before production use, configure a shared remote state backend. Wrangler OAuth and the existing Pages deployment token do not grant the Rulesets permissions Terraform needs. Store a separate, narrowly scoped token in the `coursetable/prod` Doppler config as `CLOUDFLARE_TERRAFORM_API_TOKEN`.
+
+Required token permissions:
+
+- Zone / Zone / Read for `coursetable.com`
+- Zone / Transform Rules / Edit for `coursetable.com`
+- Account / Account Rulesets / Read
+
+Use the wrapper to map that Doppler secret to the environment variable expected by the provider:
+
+```sh
+./terraform.sh <terraform arguments...>
+```
+
+## Initial import
+
+Initialize the provider:
+
+```sh
+cd cloudflare
+terraform init
+```
+
+The production zone-level `http_request_transform` ruleset was imported with:
+
+```sh
+./terraform.sh import cloudflare_ruleset.link_preview \
+  'zones/0daa4530d7630681dc3e3df2480981b7/1fdd71386af14cae9976493922b73eca'
+```
+
+Do not import it again when the shared state already contains the resource. Run `./terraform.sh plan` and reconcile every difference before applying. The configuration preserves the existing dashboard-created rule references so that adopting Terraform does not replace the live rules.
+
+## Link-preview behavior
+
+The two rules intentionally match crawler-specific user-agent tokens. Do not broaden `LinkedInBot` back to `LinkedIn`: LinkedIn's human mobile browser is also identified with a LinkedIn token and would be sent to the crawler-only page.
+
+The rules depend on the existing `/link-preview*` forwarding Page Rule, which sends rewritten requests to `https://api.coursetable.com/api/link-preview`. That Page Rule is not yet managed here and must remain active.
+
+Verify production behavior after any rule change:
+
+```sh
+# A human LinkedIn browser stays on the real page (expected: 200 and no redirect).
+curl -sS -o /dev/null -w '%{http_code} %{redirect_url}\n' \
+  -A 'LinkedInApp' \
+  'https://coursetable.com/releases/spring26'
+
+# LinkedIn's preview crawler still receives metadata (currently expected: 301 to the API endpoint).
+curl -sS -o /dev/null -w '%{http_code} %{redirect_url}\n' \
+  -A 'LinkedInBot/1.0 (compatible; Mozilla/5.0; +http://www.linkedin.com)' \
+  'https://coursetable.com/releases/spring26'
+```
+
+Format and validate changes before review:
+
+```sh
+terraform fmt -check -recursive
+terraform validate
+```

--- a/cloudflare/README.md
+++ b/cloudflare/README.md
@@ -6,13 +6,20 @@ This directory manages CourseTable's zone-level Cloudflare configuration. The fi
 
 `cloudflare_ruleset.link_preview` owns the complete `http_request_transform` phase for `coursetable.com`. Cloudflare and Terraform both require all URL Transform Rules in that phase to live in a single ruleset. **Import the existing production ruleset before running `terraform apply`.** Creating a second unmanaged resource or applying before import can conflict with the live rules.
 
-Terraform state and credentials must not be committed. Before production use, configure a shared remote state backend. Wrangler OAuth and the existing Pages deployment token do not grant the Rulesets permissions Terraform needs. Store a separate, narrowly scoped token in the `coursetable/prod` Doppler config as `CLOUDFLARE_TERRAFORM_API_TOKEN`.
+Terraform state and credentials must not be committed. State is stored in the private `coursetable-terraform-state` R2 bucket at `cloudflare/terraform.tfstate`; Terraform's native S3 lockfile prevents concurrent writes. R2 does not support bucket versioning, which is an accepted tradeoff for this small state file.
+
+Wrangler OAuth and the existing Pages deployment token do not grant the Rulesets permissions Terraform needs. Store a separate, narrowly scoped token in the `coursetable/prod` Doppler config as `CLOUDFLARE_TERRAFORM_API_TOKEN`.
 
 Required token permissions:
 
 - Zone / Zone / Read for `coursetable.com`
 - Zone / Transform Rules / Edit for `coursetable.com`
 - Account / Account Rulesets / Read
+
+The R2 backend also uses a bucket-scoped Object Read & Write API token. Store its S3 credentials in the same Doppler config as:
+
+- `CLOUDFLARE_R2_TERRAFORM_ACCESS_KEY_ID`
+- `CLOUDFLARE_R2_TERRAFORM_SECRET_ACCESS_KEY`
 
 Use the wrapper to map that Doppler secret to the environment variable expected by the provider:
 
@@ -26,7 +33,7 @@ Initialize the provider:
 
 ```sh
 cd cloudflare
-terraform init
+./terraform.sh init
 ```
 
 The production zone-level `http_request_transform` ruleset was imported with:

--- a/cloudflare/link_preview_rules.tf
+++ b/cloudflare/link_preview_rules.tf
@@ -1,0 +1,55 @@
+locals {
+  link_preview_bot_expression = "((http.user_agent contains \"facebook\") or (http.user_agent contains \"LinkedInBot\") or (http.user_agent contains \"Twitter\") or (http.user_agent contains \"pinterest\") or (http.user_agent contains \"discord\") or (http.user_agent contains \"bing\") or (http.user_agent contains \"WhatsApp\") or (http.user_agent contains \"Slack\") or (http.user_agent contains \"vercel edge functions\"))"
+}
+
+# This resource owns the entire zone-level http_request_transform phase. Import
+# the existing production ruleset before planning or applying; see README.md.
+resource "cloudflare_ruleset" "link_preview" {
+  zone_id     = var.cloudflare_zone_id
+  name        = "default"
+  description = ""
+  kind        = "zone"
+  phase       = "http_request_transform"
+
+  rules = [
+    {
+      # Preserve the existing dashboard-created reference to avoid replacing
+      # the live rule during the initial Terraform adoption.
+      ref         = "19b1d0a623394809867af715f580d6f3"
+      description = "Serve link preview card (courses)"
+      expression  = "${local.link_preview_bot_expression} and ((http.request.uri.query contains \"course-modal=\") or (http.request.uri.query contains \"ws=\")) and ((http.request.uri.path eq \"/catalog\") or (http.request.uri.path eq \"/worksheet\"))"
+      action      = "rewrite"
+      enabled     = true
+      action_parameters = {
+        uri = {
+          path = {
+            value = "/link-preview"
+          }
+        }
+      }
+    },
+    {
+      # Preserve the existing dashboard-created reference to avoid replacing
+      # the live rule during the initial Terraform adoption.
+      ref         = "a504a04e707f417eb476b2147db33e39"
+      description = "Serve link preview card (pages)"
+      expression  = "${local.link_preview_bot_expression} and starts_with(http.request.uri.path, \"/releases/\")"
+      action      = "rewrite"
+      enabled     = true
+      action_parameters = {
+        uri = {
+          path = {
+            value = "/link-preview"
+          }
+          query = {
+            expression = "concat(\"url=\", http.request.uri.path)"
+          }
+        }
+      }
+    },
+  ]
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}

--- a/cloudflare/terraform.sh
+++ b/cloudflare/terraform.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ $# -eq 0 ]]; then
+  echo "Usage: $0 <terraform arguments...>" >&2
+  exit 64
+fi
+
+exec doppler run --project coursetable --config prod -- bash -c '
+  export CLOUDFLARE_API_TOKEN="$CLOUDFLARE_TERRAFORM_API_TOKEN"
+  exec terraform "$@"
+' bash "$@"

--- a/cloudflare/terraform.sh
+++ b/cloudflare/terraform.sh
@@ -9,5 +9,7 @@ fi
 
 exec doppler run --project coursetable --config prod -- bash -c '
   export CLOUDFLARE_API_TOKEN="$CLOUDFLARE_TERRAFORM_API_TOKEN"
+  export AWS_ACCESS_KEY_ID="$CLOUDFLARE_R2_TERRAFORM_ACCESS_KEY_ID"
+  export AWS_SECRET_ACCESS_KEY="$CLOUDFLARE_R2_TERRAFORM_SECRET_ACCESS_KEY"
   exec terraform "$@"
 ' bash "$@"

--- a/cloudflare/variables.tf
+++ b/cloudflare/variables.tf
@@ -1,0 +1,5 @@
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID for coursetable.com."
+  type        = string
+  default     = "0daa4530d7630681dc3e3df2480981b7"
+}

--- a/cloudflare/versions.tf
+++ b/cloudflare/versions.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_version = ">= 1.10.0"
+
+  required_providers {
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "cloudflare" {}

--- a/cloudflare/versions.tf
+++ b/cloudflare/versions.tf
@@ -1,6 +1,24 @@
 terraform {
   required_version = ">= 1.10.0"
 
+  backend "s3" {
+    bucket = "coursetable-terraform-state"
+    key    = "cloudflare/terraform.tfstate"
+    region = "auto"
+
+    endpoints = {
+      s3 = "https://b30c1d958879fa568e6a0e7570abe0bb.r2.cloudflarestorage.com"
+    }
+
+    use_lockfile                = true
+    use_path_style              = true
+    skip_credentials_validation = true
+    skip_region_validation      = true
+    skip_requesting_account_id  = true
+    skip_metadata_api_check     = true
+    skip_s3_checksum            = true
+  }
+
   required_providers {
     cloudflare = {
       source  = "cloudflare/cloudflare"


### PR DESCRIPTION
## Summary

- add Terraform configuration for the existing CourseTable URL Transform Rules
- preserve the live ruleset and rule references during Terraform adoption
- load the scoped Cloudflare token from Doppler through a small wrapper
- document import safety, link-preview behavior, and verification commands

## Test plan

- `terraform -chdir=cloudflare fmt -check -recursive`
- `terraform -chdir=cloudflare validate`
- `shellcheck cloudflare/terraform.sh`
- `cloudflare/terraform.sh -chdir=cloudflare plan -no-color` — reports no changes against production